### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/devcontainers/base:debian
+
+# Install Playwright browsers and dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs sqlite3 \
+    && npm install -g playwright \
+    && playwright install --with-deps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+CMD ["/bin/bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "sendou.ink",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "18"
+    },
+    "ghcr.io/devcontainers/features/sqlite:1": {}
+  },
+  "forwardPorts": [5800]
+}

--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ There is a sequence of commands you need to run:
 5. `npm run dev` to run the project in development mode.
 6. Navigate to `http://localhost:5800/admin`. There press the seed button to fill the DB with test data. You can also impersonate any user (Sendou#0043 = admin).
 
+### Using the dev container
+
+If you use VS Code you can skip the manual setup by opening the repository in a
+Dev Container (requires the Dev Containers extension). The container already has
+Node 18, SQLite tools and Playwright browsers installed. After the container has
+started run `npm run dev` inside the terminal.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.


### PR DESCRIPTION
## Summary
- add devcontainer with Node 18 and SQLite
- install Playwright browsers in a Dockerfile
- document how to use the dev container

## Testing
- `npm ci --ignore-scripts` *(fails: Exit handler never called)*