### PR TITLE
Add Makefile with development helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+SHELL := bash
+
+setup:
+	if ! command -v nvm >/dev/null; then \
+	curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash; \
+	fi; \
+	source $$HOME/.nvm/nvm.sh; \
+	if ! node -v 2>/dev/null | grep -q '^v18'; then \
+	nvm install 18; \
+	fi; \
+	nvm use 18; \
+	npm install; \
+	cp .env.example .env; \
+	npm run migrate up
+
+
+dev:
+	npm run dev
+
+test:
+	npm run test:unit
+	npm run test:e2e
+
+lint:
+	npm run lint:ts
+	npm run lint:css

--- a/README.md
+++ b/README.md
@@ -44,8 +44,29 @@ Competitive Splatoon Hub with over 20k registered users.
 ### sendou.ink
 
 Prerequisites: [nvm](https://github.com/nvm-sh/nvm)
+If you don't have it installed run:
 
-There is a sequence of commands you need to run:
+```bash
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh | bash
+```
+
+You can spin up the project quickly with the `Makefile`:
+
+```bash
+make setup
+make dev
+```
+
+`make setup` will install Node.js 18 with nvm if needed.
+
+Other helpful targets include:
+
+```bash
+make test   # run unit and e2e tests
+make lint   # run TypeScript and CSS linters
+```
+
+If you prefer to run the steps manually:
 
 1. `nvm use` to switch to the correct Node version. If you don't have the correct Node.js version yet it will prompt you to install it via the `nvm install` command. If you have problems with nvm you can also install the latest LTS version of Node.js from [their website](https://nodejs.org/en/).
 2. `npm i` to install the dependencies.


### PR DESCRIPTION
## Summary
- add a Makefile with common development tasks
- document Makefile usage in README
- setup now installs nvm and Node.js 18 automatically

## Testing
- `npm run lint:ts` *(fails: ESLint couldn't find config)*
- `npm run test:unit` *(fails: uvu not found)*
- `npm run test:e2e` *(fails: network EHOSTUNREACH)*
- `npm run lint:css` *(fails: stylelint not found)*