### PR TITLE
Add unslugify server tests

### DIFF
--- a/app/utils/unslugify.server.test.ts
+++ b/app/utils/unslugify.server.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test, vi } from "vitest";
+
+// Mock weapon translations to keep the test lightweight
+vi.mock("../../locales/en/weapons.json", () => ({
+  default: {
+    MAIN_500: "Splattershot",
+  },
+}));
+
+import { weaponNameSlugToId } from "./unslugify.server";
+
+describe("weaponNameSlugToId", () => {
+  test("returns numeric id for known slug", () => {
+    expect(weaponNameSlugToId("splattershot")).toBe(500);
+  });
+
+  test("returns null for unknown slug", () => {
+    expect(weaponNameSlugToId("unknown")).toBeNull();
+  });
+
+  test("returns null when slug is undefined", () => {
+    expect(weaponNameSlugToId(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add new test for weaponNameSlugToId
- verify known slug mapping and null cases using a mocked weapons map

## Testing
- `npm ci` *(fails: Exit handler never called)*
- `VITE_SITE_DOMAIN=http://localhost:5173 npx vitest run` *(fails: connect EHOSTUNREACH)*